### PR TITLE
adding social shares to article pages

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -10,6 +10,7 @@ import { portableTextComponents } from "@/utils/portableTextComponents";
 import TableOfContents from "@/components/tableOfContents"
 import AdventureHero from "@/components/adventure/AdventureHero"
 import { MobileTOC } from "@/components/MobileTOC"
+import SocialShare from "@/components/SocialShare"
 
 interface PageProps {
     params: Promise<{ id: string }>
@@ -50,6 +51,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
             title: post.title,
             description,
             images: post.mainImage ? [post.mainImage] : [],
+            url: `https://kyle.czajkowski.tech/blog/${id}`,
             type: 'article',
             publishedTime: post.publishedAt,
             authors: [post.author?.name || 'Kyle Czajkowski'],
@@ -118,7 +120,12 @@ export default async function BlogPostPage({ params }: PageProps) {
 
                 < div className="space-y-4" >
                     <h1 className="text-3xl sm:text-4xl font-bold">{post.title}</h1>
-
+                    <SocialShare
+                        url={`https://kyle.czajkowski.tech/blog/${post.slug}`}
+                        variant="buttons"
+                        size="md"
+                        className="mb-6 pb-6 border-b border-border"
+                    />
                     <div className="flex items-center gap-4">
                         <Avatar>
                             <AvatarImage src={post.author?.image} />

--- a/app/gear/reviews/[slug]/page.tsx
+++ b/app/gear/reviews/[slug]/page.tsx
@@ -43,6 +43,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
             title: `${review.brand} ${review.gearName} Review`,
             description: review.excerpt,
             images: review.mainImage ? [review.mainImage] : [],
+            url: `https://kyle.czajkowski.tech/gear/reviews/${slug}`,
             type: 'article',
             publishedTime: review.publishedAt,
             modifiedTime: review.updatedAt || review.publishedAt,

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -16,6 +16,7 @@ import { GearUsedSection } from "@/components/adventure/GearUsedSection"
 import { MobileTOC } from "@/components/MobileTOC"
 import GPXRouteSection from "@/components/adventure/GPXRouteSection"
 import { portableTextComponents } from "@/utils/portableTextComponents"
+import SocialShare from "@/components/SocialShare"
 
 interface PageProps {
     params: Promise<{ slug: string }>
@@ -199,7 +200,11 @@ export default async function GuidePage({ params }: PageProps) {
                             {guide.difficulty || 'All Levels'}
                         </Badge>
                     </div>
-
+                    <SocialShare
+                        url={`https://kyle.czajkowski.tech/gear/guides/${guide.slug}`}
+                        title={`${guide.title}`}
+                        variant="buttons"
+                    />
                     {/* Guide Meta Grid */}
                     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                         {/* Guide Type */}

--- a/app/reports/[slug]/page.tsx
+++ b/app/reports/[slug]/page.tsx
@@ -15,6 +15,7 @@ import AdventureHero from "@/components/adventure/AdventureHero"
 import { GearUsedSection } from "@/components/adventure/GearUsedSection"
 import { MobileTOC } from "@/components/MobileTOC"
 import GPXRouteSection from "@/components/adventure/GPXRouteSection"
+import SocialShare from "@/components/SocialShare"
 
 interface PageProps {
     params: Promise<{ slug: string }>
@@ -63,6 +64,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
             title: `${tripReport.title} - Adventure Report`,
             description,
             images: tripReport.mainImage ? [tripReport.mainImage] : [],
+            url: `https://kyle.czajkowski.tech/reports/${slug}`,
             type: 'article',
             publishedTime: tripReport.publishedAt,
             authors: [tripReport.author?.name || 'Kyle Czajkowski'],
@@ -207,6 +209,11 @@ export default async function TripReportPage({ params }: PageProps) {
                     <div className="flex items-start justify-between">
                         <div className="flex-1">
                             <h1 className="text-3xl sm:text-4xl font-bold mb-2">{tripReport.title}</h1>
+                            <SocialShare
+                                url={`https://kyle.czajkowski.tech/reports/${tripReport.slug}`}
+                                title={`${tripReport.title} - Adventure Report`}
+                                size="md"
+                            />
                             {/* Explicit Achievement Callout from Sanity */}
                             {tripReport.achievement && (
                                 <div className={`border rounded-lg p-3 mb-4 ${getAchievementStyling(tripReport.achievement.type).bgColor}`}>

--- a/components/SocialShare.tsx
+++ b/components/SocialShare.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { FaBluesky, FaLinkedinIn, FaFacebook, FaTwitter } from "react-icons/fa6";
+import {
+    Share2,
+    Copy,
+    Check,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface SocialShareProps {
+    /** The URL to share */
+    url: string;
+    /** Custom title for sharing (falls back to page title if not provided) */
+    title?: string;
+    /** Custom description for sharing (falls back to meta description if not provided) */
+    description?: string;
+    /** Additional CSS classes */
+    className?: string;
+    /** Size variant */
+    size?: 'sm' | 'md' | 'lg';
+    /** Display variant */
+    variant?: 'buttons' | 'compact' | 'minimal';
+    /** Whether to show labels next to icons */
+    showLabels?: boolean;
+}
+
+interface SocialPlatform {
+    name: string;
+    icon: React.ComponentType<{ className?: string; size?: number }>;
+    shareUrl: (url: string, title: string, description?: string) => string;
+    color: string;
+    hoverColor: string;
+}
+
+const platforms: SocialPlatform[] = [
+    {
+        name: 'Twitter',
+        icon: FaTwitter,
+        shareUrl: (url, title) => `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(url)}`,
+        color: 'text-blue-400',
+        hoverColor: 'hover:bg-blue-50 dark:hover:bg-blue-900/20'
+    },
+    {
+        name: 'Facebook',
+        icon: FaFacebook,
+        shareUrl: (url) => `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`,
+        color: 'text-blue-600',
+        hoverColor: 'hover:bg-blue-50 dark:hover:bg-blue-900/20'
+    },
+    {
+        name: 'LinkedIn',
+        icon: FaLinkedinIn,
+        shareUrl: (url, title, description) => {
+            const params = new URLSearchParams({
+                url,
+                title,
+                ...(description && { summary: description })
+            });
+            return `https://www.linkedin.com/sharing/share-offsite/?${params.toString()}`;
+        },
+        color: 'text-blue-700',
+        hoverColor: 'hover:bg-blue-50 dark:hover:bg-blue-900/20'
+    },
+    {
+        name: 'Bluesky',
+        icon: FaBluesky,
+        shareUrl: (url, title) => `https://bsky.app/intent/compose?text=${encodeURIComponent(`${title} ${url}`)}`,
+        color: 'text-sky-500',
+        hoverColor: 'hover:bg-sky-50 dark:hover:bg-sky-900/20'
+    }
+];
+
+export default function SocialShare({
+    url,
+    title,
+    description,
+    className = '',
+    size = 'md',
+    variant = 'buttons',
+    showLabels = false,
+}: SocialShareProps) {
+    const [copied, setCopied] = useState(false);
+
+    // Auto-generate title and description from page metadata if not provided
+    const shareTitle = title || (typeof document !== 'undefined' ?
+        document.querySelector('meta[property="og:title"]')?.getAttribute('content') ||
+        document.title : '');
+
+    const shareDescription = description || (typeof document !== 'undefined' ?
+        document.querySelector('meta[property="og:description"]')?.getAttribute('content') ||
+        document.querySelector('meta[name="description"]')?.getAttribute('content') : '') || undefined;
+
+    // Handle social platform sharing
+    const handleShare = (platform: SocialPlatform) => {
+        const shareUrl = platform.shareUrl(url, shareTitle, shareDescription);
+
+        // Track sharing event with GTM
+        if (typeof window !== 'undefined' && window.gtag) {
+            window.gtag('event', 'share', {
+                method: platform.name.toLowerCase(),
+                content_type: getContentType(),
+                content_id: getContentId(),
+            });
+        }
+
+        // Open share window
+        window.open(shareUrl, '_blank', 'width=600,height=400,scrollbars=yes,resizable=yes');
+    };
+
+    // Handle copy link
+    const handleCopyLink = async () => {
+        try {
+            await navigator.clipboard.writeText(url);
+            setCopied(true);
+
+            // Track copy event
+            if (typeof window !== 'undefined' && window.gtag) {
+                window.gtag('event', 'share', {
+                    method: 'copy_link',
+                    content_type: getContentType(),
+                    content_id: getContentId(),
+                });
+            }
+
+            // Reset copied state after 2 seconds
+            setTimeout(() => setCopied(false), 2000);
+        } catch (err) {
+            console.error('Failed to copy link:', err);
+            // Fallback: select the URL for manual copying
+            prompt('Copy this link:', url);
+        }
+    };
+
+    // Helper functions for analytics
+    const getContentType = () => {
+        if (typeof window !== 'undefined') {
+            const pathname = window.location.pathname;
+            if (pathname.includes('/blog/')) return 'blog_post';
+            if (pathname.includes('/reports/')) return 'trip_report';
+            if (pathname.includes('/gear/reviews/')) return 'gear_review';
+            if (pathname.includes('/guides/')) return 'guide';
+        }
+        return 'page';
+    };
+
+    const getContentId = () => {
+        if (typeof window !== 'undefined') {
+            const pathname = window.location.pathname;
+            const segments = pathname.split('/');
+            return segments[segments.length - 1] || 'home';
+        }
+        return 'unknown';
+    };
+
+    // Size configurations
+    const sizeConfig = {
+        sm: {
+            buttonSize: 'h-8 w-8',
+            iconSize: 'h-4 w-4',
+            spacing: 'gap-2',
+            text: 'text-xs'
+        },
+        md: {
+            buttonSize: 'h-9 w-9',
+            iconSize: 'h-4 w-4',
+            spacing: 'gap-3',
+            text: 'text-sm'
+        },
+        lg: {
+            buttonSize: 'h-10 w-10',
+            iconSize: 'h-5 w-5',
+            spacing: 'gap-4',
+            text: 'text-sm'
+        }
+    };
+
+    const config = sizeConfig[size];
+
+    // Render different variants
+    if (variant === 'compact') {
+        return (
+            <Card className={cn('bg-muted/30 border-border', className)}>
+                <CardContent className="p-3">
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <Share2 className="h-4 w-4" />
+                            <span>Share this post</span>
+                        </div>
+                        <div className={cn('flex', config.spacing)}>
+                            {platforms.map((platform) => {
+                                const Icon = platform.icon;
+                                return (
+                                    <Button
+                                        key={platform.name}
+                                        variant="ghost"
+                                        size="icon"
+                                        className={cn(
+                                            config.buttonSize,
+                                            platform.color,
+                                            platform.hoverColor,
+                                            'transition-colors'
+                                        )}
+                                        onClick={() => handleShare(platform)}
+                                        title={`Share on ${platform.name}`}
+                                    >
+                                        <Icon className={config.iconSize} />
+                                    </Button>
+                                );
+                            })}
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                className={cn(
+                                    config.buttonSize,
+                                    copied ? 'text-green-600' : 'text-muted-foreground',
+                                    'hover:bg-accent transition-colors'
+                                )}
+                                onClick={handleCopyLink}
+                                title={copied ? 'Link copied!' : 'Copy link'}
+                            >
+                                {copied ? <Check className={config.iconSize} /> : <Copy className={config.iconSize} />}
+                            </Button>
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    if (variant === 'minimal') {
+        return (
+            <div className={cn('flex items-center', config.spacing, className)}>
+                {platforms.map((platform) => {
+                    const Icon = platform.icon;
+                    return (
+                        <Button
+                            key={platform.name}
+                            variant="ghost"
+                            size="icon"
+                            className={cn(
+                                config.buttonSize,
+                                platform.color,
+                                platform.hoverColor,
+                                'transition-colors'
+                            )}
+                            onClick={() => handleShare(platform)}
+                            title={`Share on ${platform.name}`}
+                        >
+                            <Icon className={config.iconSize} />
+                        </Button>
+                    );
+                })}
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className={cn(
+                        config.buttonSize,
+                        copied ? 'text-green-600' : 'text-muted-foreground',
+                        'hover:bg-accent transition-colors'
+                    )}
+                    onClick={handleCopyLink}
+                    title={copied ? 'Link copied!' : 'Copy link'}
+                >
+                    {copied ? <Check className={config.iconSize} /> : <Copy className={config.iconSize} />}
+                </Button>
+            </div>
+        );
+    }
+
+    // Default 'buttons' variant
+    return (
+        <div className={cn('flex flex-wrap items-center', config.spacing, className)}>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Share2 className="h-4 w-4" />
+                <span className="hidden sm:inline">Share:</span>
+            </div>
+
+            <div className={cn('flex flex-wrap', config.spacing)}>
+                {platforms.map((platform) => {
+                    const Icon = platform.icon;
+                    return (
+                        <Button
+                            key={platform.name}
+                            variant="outline"
+                            size={showLabels ? 'sm' : 'icon'}
+                            className={cn(
+                                !showLabels && config.buttonSize,
+                                platform.color,
+                                platform.hoverColor,
+                                'transition-colors border-border bg-background',
+                                // Mobile optimizations
+                                'min-w-0 flex-shrink-0'
+                            )}
+                            onClick={() => handleShare(platform)}
+                            title={`Share on ${platform.name}`}
+                        >
+                            <Icon className={config.iconSize} />
+                            {showLabels && (
+                                <span className={cn('ml-1', config.text)}>{platform.name}</span>
+                            )}
+                        </Button>
+                    );
+                })}
+
+                <Button
+                    variant="outline"
+                    size={showLabels ? 'sm' : 'icon'}
+                    className={cn(
+                        !showLabels && config.buttonSize,
+                        copied ? 'text-green-600 border-green-200' : 'text-muted-foreground',
+                        'transition-colors border-border bg-background',
+                        'hover:bg-accent min-w-0 flex-shrink-0'
+                    )}
+                    onClick={handleCopyLink}
+                    title={copied ? 'Link copied!' : 'Copy link'}
+                >
+                    {copied ? <Check className={config.iconSize} /> : <Copy className={config.iconSize} />}
+                    {showLabels && (
+                        <span className={cn('ml-1', config.text)}>
+                            {copied ? 'Copied!' : 'Copy'}
+                        </span>
+                    )}
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/components/gear/GearReviewDetail.tsx
+++ b/components/gear/GearReviewDetail.tsx
@@ -22,6 +22,7 @@ import { PortableText } from '@portabletext/react'
 import { GearReview } from "@/lib/cmsProvider"
 import styles from '@/styles/GearReviewDetail.module.css'
 import EnhancedImageGallery from "./EnhancedImageGallery"
+import SocialShare from "../SocialShare"
 
 interface GearReviewDetailProps {
     review: GearReview
@@ -167,6 +168,11 @@ export default function GearReviewDetail({ review }: GearReviewDetailProps) {
                                     </div>
                                 )}
                             </div>
+                            <SocialShare
+                                url={`https://kyle.czajkowski.tech/gear/reviews/${review.slug}`}
+                                title={`${review.brand} ${review.gearName} Review`}
+                                variant="buttons"
+                            />
                         </div>
                     </div>
                 </header>

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    gtag?: (...args: any[]) => void;
+  }
+}
+
+export {};


### PR DESCRIPTION
Features:

Reusable SocialShare component for Twitter, Facebook, LinkedIn, and Bluesky
Auto-detects page metadata (title, description) from OpenGraph tags
Copy link functionality with success feedback
Mobile-responsive with 3 display variants (buttons, compact, minimal)
GTM analytics tracking for share events
Uses react-icons for platform icons, matches existing Tailwind design patterns

Usage:

```tsx
<SocialShare 
  url={`https://kyle.czajkowski.tech/blog/${post.slug}`}
  variant="buttons" 
  size="md"
/>
```
