### PR TITLE
Feature/gear list url

### DIFF
--- a/app/gear/page.tsx
+++ b/app/gear/page.tsx
@@ -4,6 +4,7 @@ import GearFeatured from '@/components/gear/GearFeatured'
 import GearGrid from '@/components/gear/GearGrid'
 import GearStats from '@/components/gear/GearStats'
 import { AdventureNav } from '@/components/navigation/AdventureNav'
+import { Suspense } from 'react'
 
 export const metadata = {
   title: 'Gear Room | Kyle Czajkowski',
@@ -28,6 +29,25 @@ export const metadata = {
     canonical: 'https://kyle.czajkowski.tech/gear'
   }
 };
+
+// Wrapper component to handle search params
+function GearGridWrapper({ gear, categories, brands, packLists }: {
+  gear: any[]
+  categories: string[]
+  brands: string[]
+  packLists: string[]
+}) {
+  return (
+    <Suspense fallback={<div>Loading filters...</div>}>
+      <GearGrid
+        gear={gear}
+        categories={categories}
+        brands={brands}
+        packLists={packLists}
+      />
+    </Suspense>
+  )
+}
 
 export default async function GearPage() {
   const allGear = await getAllGear()
@@ -56,7 +76,7 @@ export default async function GearPage() {
       {/* Main Gear Grid with Filters */}
       <section className="container mx-auto px-4 py-12">
         <h2 className="text-3xl font-bold mb-8 text-center">Gear Closet</h2>
-        <GearGrid
+        <GearGridWrapper
           gear={allGear}
           categories={categories}
           brands={brands}

--- a/components/gear/GearGrid.tsx
+++ b/components/gear/GearGrid.tsx
@@ -1,12 +1,14 @@
 "use client"
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect, useRef } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { Search, Filter, X, ExternalLink, Weight, Package, Eye, EyeOff, DollarSign } from 'lucide-react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Search, Filter, X, ExternalLink, Weight, Package, Eye, EyeOff, DollarSign, Share2 } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { GearItem } from '@/utils/notionGear'
+import { createGearSlug, buildGearUrl, parseGearFilters, findGearBySlug } from '@/lib/gearUrlUtils'
 import styles from '@/styles/GearGrid.module.css'
 
 interface GearGridProps {
@@ -17,13 +19,138 @@ interface GearGridProps {
 }
 
 const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
-  const [searchTerm, setSearchTerm] = useState('')
-  const [selectedCategory, setSelectedCategory] = useState<string>('')
-  const [selectedBrand, setSelectedBrand] = useState<string>('')
-  const [selectedPackList, setSelectedPackList] = useState<string>('')
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const itemRefs = useRef<{ [key: string]: HTMLDivElement | null }>({})
+  const gearGridRef = useRef<HTMLDivElement | null>(null)
+  const hasScrolledRef = useRef(false)
+
+  // Parse initial state from URL
+  const initialFilters = parseGearFilters(searchParams)
+  
+  const [searchTerm, setSearchTerm] = useState('') // Search stays local, not from URL
+  const [selectedCategory, setSelectedCategory] = useState(initialFilters.category)
+  const [selectedBrand, setSelectedBrand] = useState(initialFilters.brand)
+  const [selectedPackList, setSelectedPackList] = useState(initialFilters.packList)
   const [showRetired, setShowRetired] = useState(false)
   const [sortBy, setSortBy] = useState<'name' | 'weight' | 'cost' | 'date'>('name')
   const [showFilters, setShowFilters] = useState(false)
+
+  // Update URL when filters change (excluding search)
+  const updateUrl = (newFilters: any) => {
+    const url = buildGearUrl({
+      category: newFilters.category || selectedCategory,
+      brand: newFilters.brand || selectedBrand,
+      packList: newFilters.packList || selectedPackList,
+      // search is intentionally excluded from URL
+    })
+    router.push(url, { scroll: false })
+  }
+
+  // Scroll to gear grid when filters are applied
+  const scrollToGearGrid = () => {
+    if (gearGridRef.current) {
+      const headerOffset = 100 // Adjust based on your header height
+      const elementPosition = gearGridRef.current.getBoundingClientRect().top
+      const offsetPosition = elementPosition + window.pageYOffset - headerOffset
+
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: 'smooth'
+      })
+    }
+  }
+
+  // Handle filter changes with URL updates
+  const handleCategoryChange = (category: string) => {
+    setSelectedCategory(category)
+    updateUrl({ category })
+    if (category) {
+      hasScrolledRef.current = true
+      scrollToGearGrid()
+    }
+  }
+
+  const handleBrandChange = (brand: string) => {
+    setSelectedBrand(brand)
+    updateUrl({ brand })
+    if (brand) {
+      hasScrolledRef.current = true
+      scrollToGearGrid()
+    }
+  }
+
+  const handlePackListChange = (packList: string) => {
+    setSelectedPackList(packList)
+    updateUrl({ packList })
+    if (packList) {
+      hasScrolledRef.current = true
+      scrollToGearGrid()
+    }
+  }
+
+  const handleSearchChange = (search: string) => {
+    setSearchTerm(search) // Update search immediately, no URL updates or scrolling
+  }
+
+  // Scroll to item if specified in URL, or to gear grid if filters are present
+  useEffect(() => {
+    const itemSlug = searchParams.get('item')
+    const hasFilters = selectedCategory || selectedBrand || selectedPackList // removed searchTerm
+    
+    if (itemSlug) {
+      // Reset scroll flag for item-specific scrolling
+      hasScrolledRef.current = false
+      // Wait for the component to render, then scroll to specific item
+      setTimeout(() => {
+        const element = itemRefs.current[itemSlug]
+        if (element) {
+          element.scrollIntoView({ 
+            behavior: 'smooth', 
+            block: 'center'
+          })
+          // Add a subtle highlight effect
+          element.style.boxShadow = '0 0 0 3px rgba(34, 197, 94, 0.3)'
+          setTimeout(() => {
+            element.style.boxShadow = ''
+          }, 2000)
+        }
+      }, 100)
+    } else if (hasFilters && !hasScrolledRef.current) {
+      // Only scroll to gear grid if we haven't already scrolled
+      setTimeout(() => {
+        scrollToGearGrid()
+        hasScrolledRef.current = true
+      }, 100)
+    } else if (!hasFilters) {
+      // Reset scroll flag when filters are cleared
+      hasScrolledRef.current = false
+    }
+  }, [searchParams, gear, selectedCategory, selectedBrand, selectedPackList]) // removed searchTerm
+
+  // Generate shareable link for specific item
+  const getItemShareLink = (item: GearItem) => {
+    const itemSlug = createGearSlug(item.title)
+    const currentFilters = {
+      category: selectedCategory,
+      brand: selectedBrand,
+      packList: selectedPackList,
+      // search intentionally excluded from shareable links
+    }
+    return buildGearUrl(currentFilters, itemSlug)
+  }
+
+  // Copy link to clipboard
+  const copyItemLink = async (item: GearItem) => {
+    const url = `${window.location.origin}${getItemShareLink(item)}`
+    try {
+      await navigator.clipboard.writeText(url)
+      // You could add a toast notification here
+      console.log('Link copied to clipboard!')
+    } catch (err) {
+      console.error('Failed to copy link:', err)
+    }
+  }
 
   const filteredGear = useMemo(() => {
     let filtered = gear
@@ -75,13 +202,23 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
   }, [gear, searchTerm, selectedCategory, selectedBrand, selectedPackList, showRetired, sortBy])
 
   const clearFilters = () => {
-    setSearchTerm('')
+    setSearchTerm('') // Clear search
     setSelectedCategory('')
     setSelectedBrand('')
     setSelectedPackList('')
+    hasScrolledRef.current = false // Reset scroll flag when clearing filters
+    router.push('/gear', { scroll: false })
   }
 
   const activeFiltersCount = [selectedCategory, selectedBrand, selectedPackList].filter(Boolean).length
+
+  // Development placeholder image
+  const getImageSrc = (item: GearItem) => {
+    if (process.env.NODE_ENV === 'development') {
+      return '/gear-placeholder.svg' 
+    }
+    return item.imageUrl
+  }
 
   return (
     <div className={styles.container}>
@@ -93,7 +230,7 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
             type="text"
             placeholder="Search gear..."
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e) => handleSearchChange(e.target.value)}
             className={styles.searchInput}
           />
         </div>
@@ -138,7 +275,7 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
             <label>Category</label>
             <select
               value={selectedCategory}
-              onChange={(e) => setSelectedCategory(e.target.value)}
+              onChange={(e) => handleCategoryChange(e.target.value)}
               className={styles.filterSelect}
             >
               <option value="">All Categories</option>
@@ -152,7 +289,7 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
             <label>Brand</label>
             <select
               value={selectedBrand}
-              onChange={(e) => setSelectedBrand(e.target.value)}
+              onChange={(e) => handleBrandChange(e.target.value)}
               className={styles.filterSelect}
             >
               <option value="">All Brands</option>
@@ -166,7 +303,7 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
             <label>Pack List</label>
             <select
               value={selectedPackList}
-              onChange={(e) => setSelectedPackList(e.target.value)}
+              onChange={(e) => handlePackListChange(e.target.value)}
               className={styles.filterSelect}
             >
               <option value="">All Pack Lists</option>
@@ -191,67 +328,68 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
       </div>
 
       {/* Gear Grid */}
-      <div className={styles.gearGrid}>
-        {filteredGear.map((item) => (
-          <Card
-            key={item.id}
-            className={`${styles.gearCard} ${item.isRetired ? styles.retired : ''}`}
-          >
-            <div className={styles.imageWrapper}>
-              {item.imageUrl ? (
-                <Image
-                  src={item.imageUrl}
-                  alt={item.title}
-                  width={200}
-                  height={200}
-                  loading="lazy"
-                  placeholder="empty"
-                  onError={(e) => {
-                    e.currentTarget.style.display = 'none';
-                  }}
-                  className={styles.image}
-                />
-              ) : (
-                <div className={styles.imagePlaceholder}>
-                  <Package size={40} />
-                </div>
-              )}
-              {item.isRetired && (
-                <div className={styles.retiredBadge}>Retired</div>
-              )}
-            </div>
-
-            <CardContent className={styles.content}>
-              <h3 className={styles.itemTitle}>{item.title}</h3>
-              <p className={styles.itemProduct}>{item.product}</p>
-
-              {item.brand && (
-                <Badge variant="outline" className={styles.brandBadge}>
-                  {item.brand}
-                </Badge>
-              )}
-
-              <div className={styles.specs}>
-                {item.weight_oz && (
-                  <div className={styles.spec}>
-                    <Weight size={14} />
-                    <span>{item.weight_oz} oz</span>
+      <div ref={gearGridRef} className={styles.gearGrid}>
+        {filteredGear.map((item) => {
+          const itemSlug = createGearSlug(item.title)
+          return (
+            <Card
+              key={item.id}
+              ref={(el) => { itemRefs.current[itemSlug] = el }}
+              className={`${styles.gearCard} ${item.isRetired ? styles.retired : ''}`}
+            >
+              <div className={styles.imageWrapper}>
+                {getImageSrc(item) ? (
+                  <Image
+                    src={getImageSrc(item)!}
+                    alt={item.title}
+                    width={300}
+                    height={200}
+                    className={styles.image}
+                  />
+                ) : (
+                  <div className={styles.imagePlaceholder}>
+                    <Package size={48} />
                   </div>
                 )}
-                {item.cost && (
-                  <div className={styles.spec}>
-                    <DollarSign size={14} />
-                    <span>{item.cost}</span>
-                  </div>
-                )}
+                
+                {/* Share button */}
+                <button
+                  onClick={() => copyItemLink(item)}
+                  className={styles.shareButton}
+                  title="Copy link to this item"
+                >
+                  <Share2 size={16} />
+                </button>
               </div>
 
-              {item.packLists.length > 0 && (
-                <div className={styles.packLists}>
-                  <p className={styles.packListLabel}>Used in:</p>
-                  <div className={styles.packListTags}>
-                    {item.packLists.slice(0, 2).map((list, index) => (
-                      <span key={index} className={styles.packListTag}>
+              <CardContent className={styles.content}>
+                <h3 className={styles.itemTitle}>{item.title}</h3>
+                <p className={styles.itemProduct}>{item.product}</p>
+
+                {item.brand && (
+                  <Badge variant="outline" className={styles.brandBadge}>
+                    {item.brand}
+                  </Badge>
+                )}
+
+                <div className={styles.metaInfo}>
+                  {item.weight_oz && (
+                    <div className={styles.metaItem}>
+                      <Weight size={14} />
+                      <span>{item.weight_oz} oz</span>
+                    </div>
+                  )}
+                  {item.cost && (
+                    <div className={styles.metaItem}>
+                      <span>${item.cost}</span>
+                    </div>
+                  )}
+                </div>
+
+                {item.packLists.length > 0 && (
+                  <div className={styles.packLists}>
+                    {item.packLists.slice(0, 2).map(list => (
+                      <span key={list} className={styles.packListTag}>
                         {list}
                       </span>
                     ))}
@@ -261,23 +399,23 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
                       </span>
                     )}
                   </div>
-                </div>
-              )}
+                )}
 
-              {item.url && (
-                <Link
-                  href={item.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={styles.link}
-                >
-                  <span>View Product</span>
-                  <ExternalLink size={14} />
-                </Link>
-              )}
-            </CardContent>
-          </Card>
-        ))}
+                {item.url && (
+                  <Link
+                    href={item.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.link}
+                  >
+                    <span>View Product</span>
+                    <ExternalLink size={14} />
+                  </Link>
+                )}
+              </CardContent>
+            </Card>
+          )
+        })}
       </div>
 
       {filteredGear.length === 0 && (

--- a/components/gear/GearGrid.tsx
+++ b/components/gear/GearGrid.tsx
@@ -35,6 +35,7 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
   const [showRetired, setShowRetired] = useState(false)
   const [sortBy, setSortBy] = useState<'name' | 'weight' | 'cost' | 'date'>('name')
   const [showFilters, setShowFilters] = useState(false)
+  const [toastMessage, setToastMessage] = useState('')
 
   // Update URL when filters change (excluding search)
   const updateUrl = (newFilters: any) => {
@@ -145,10 +146,12 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
     const url = `${window.location.origin}${getItemShareLink(item)}`
     try {
       await navigator.clipboard.writeText(url)
-      // You could add a toast notification here
-      console.log('Link copied to clipboard!')
+      setToastMessage(`Link copied for ${item.title}`)
+      setTimeout(() => setToastMessage(''), 3000) // Hide toast after 3 seconds
     } catch (err) {
       console.error('Failed to copy link:', err)
+      setToastMessage('Failed to copy link')
+      setTimeout(() => setToastMessage(''), 3000)
     }
   }
 
@@ -327,7 +330,7 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
         <p>Showing {filteredGear.length} items</p>
       </div>
 
-      {/* Gear Grid */}
+      {/* Gear Grid - Using your original structure */}
       <div ref={gearGridRef} className={styles.gearGrid}>
         {filteredGear.map((item) => {
           const itemSlug = createGearSlug(item.title)
@@ -342,24 +345,24 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
                   <Image
                     src={getImageSrc(item)!}
                     alt={item.title}
-                    width={300}
+                    width={200}
                     height={200}
+                    loading="lazy"
+                    placeholder="empty"
+                    onError={(e) => {
+                      e.currentTarget.style.display = 'none';
+                    }}
                     className={styles.image}
                   />
                 ) : (
                   <div className={styles.imagePlaceholder}>
-                    <Package size={48} />
+                    <Package size={40} />
                   </div>
                 )}
                 
-                {/* Share button */}
-                <button
-                  onClick={() => copyItemLink(item)}
-                  className={styles.shareButton}
-                  title="Copy link to this item"
-                >
-                  <Share2 size={16} />
-                </button>
+                {item.isRetired && (
+                  <div className={styles.retiredBadge}>Retired</div>
+                )}
               </div>
 
               <CardContent className={styles.content}>
@@ -372,15 +375,16 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
                   </Badge>
                 )}
 
-                <div className={styles.metaInfo}>
+                <div className={styles.specs}>
                   {item.weight_oz && (
-                    <div className={styles.metaItem}>
+                    <div className={styles.spec}>
                       <Weight size={14} />
                       <span>{item.weight_oz} oz</span>
                     </div>
                   )}
                   {item.cost && (
-                    <div className={styles.metaItem}>
+                    <div className={styles.spec}>
+                      <DollarSign size={14} />
                       <span>${item.cost}</span>
                     </div>
                   )}
@@ -388,30 +392,44 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
 
                 {item.packLists.length > 0 && (
                   <div className={styles.packLists}>
-                    {item.packLists.slice(0, 2).map(list => (
-                      <span key={list} className={styles.packListTag}>
-                        {list}
-                      </span>
-                    ))}
-                    {item.packLists.length > 2 && (
-                      <span className={styles.packListTag}>
-                        +{item.packLists.length - 2}
-                      </span>
-                    )}
+                    <p className={styles.packListLabel}>Used in:</p>
+                    <div className={styles.packListTags}>
+                      {item.packLists.slice(0, 2).map((list, index) => (
+                        <span key={index} className={styles.packListTag}>
+                          {list}
+                        </span>
+                      ))}
+                      {item.packLists.length > 2 && (
+                        <span className={styles.packListTag}>
+                          +{item.packLists.length - 2}
+                        </span>
+                      )}
+                    </div>
                   </div>
                 )}
 
-                {item.url && (
-                  <Link
-                    href={item.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={styles.link}
+                <div className={styles.linkContainer}>
+                  {item.url && (
+                    <Link
+                      href={item.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={styles.link}
+                    >
+                      <span>View Product</span>
+                      <ExternalLink size={14} />
+                    </Link>
+                  )}
+                  
+                  <button
+                    onClick={() => copyItemLink(item)}
+                    className={styles.shareLink}
+                    title="Copy link to this item"
                   >
-                    <span>View Product</span>
-                    <ExternalLink size={14} />
-                  </Link>
-                )}
+                    <Share2 size={14} />
+                    <span>Share</span>
+                  </button>
+                </div>
               </CardContent>
             </Card>
           )
@@ -425,6 +443,16 @@ const GearGrid = ({ gear, categories, brands, packLists }: GearGridProps) => {
           <button onClick={clearFilters} className={styles.clearButton}>
             Clear Filters
           </button>
+        </div>
+      )}
+
+      {/* Toast Notification */}
+      {toastMessage && (
+        <div className={styles.toast}>
+          <div className={styles.toastContent}>
+            <Share2 size={16} />
+            <span>{toastMessage}</span>
+          </div>
         </div>
       )}
     </div>

--- a/lib/gearUrlUtils.ts
+++ b/lib/gearUrlUtils.ts
@@ -1,0 +1,73 @@
+/**
+ * Generate a URL-friendly slug from gear title
+ */
+export const createGearSlug = (title: string): string => {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '') // Remove special characters
+    .replace(/\s+/g, '-') // Replace spaces with hyphens
+    .replace(/-+/g, '-') // Replace multiple hyphens with single
+    .trim();
+};
+
+/**
+ * Find gear item by slug
+ */
+export const findGearBySlug = (gear: any[], slug: string) => {
+  return gear.find(item => createGearSlug(item.title) === slug);
+};
+
+/**
+ * Build gear URL with filters and optional item
+ */
+export const buildGearUrl = (filters: {
+  category?: string;
+  brand?: string;
+  packList?: string;
+  search?: string;
+}, itemSlug?: string): string => {
+  const params = new URLSearchParams();
+  
+  // Add filters
+  if (filters.category) params.set('category', filters.category);
+  if (filters.brand) params.set('brand', filters.brand);
+  if (filters.packList) params.set('packList', filters.packList);
+  if (filters.search) params.set('search', filters.search);
+  
+  // Add item
+  if (itemSlug) params.set('item', itemSlug);
+  
+  const queryString = params.toString();
+  return queryString ? `/gear?${queryString}` : '/gear';
+};
+
+/**
+ * Parse URL search params to filter state
+ */
+export const parseGearFilters = (searchParams: URLSearchParams) => {
+  return {
+    category: searchParams.get('category') || '',
+    brand: searchParams.get('brand') || '',
+    packList: searchParams.get('packList') || '',
+    search: searchParams.get('search') || '',
+    item: searchParams.get('item') || '',
+  };
+};
+
+/**
+ * Safely encode filter values for URLs while preserving readability
+ */
+export const encodeFilterValue = (value: string): string => {
+  return encodeURIComponent(value);
+};
+
+/**
+ * Safely decode filter values from URLs
+ */
+export const decodeFilterValue = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value; // Return original if decoding fails
+  }
+};

--- a/lib/gearUrlUtils.ts
+++ b/lib/gearUrlUtils.ts
@@ -1,73 +1,82 @@
 /**
  * Generate a URL-friendly slug from gear title
+ * In the components, we can now generate links like:
+ * const linkToSpecificGear = buildGearUrl(
+ * { category: 'ski-gear' }, 
+ * 'findr-102-skis'
+ * );  "/gear?category=ski-gear&item=findr-102-skis"
+ *
+ * Or just filters:
+ * const linkToCategory = buildGearUrl({ category: 'backpacking' }); 
+ * "/gear?category=backpacking"
  */
 export const createGearSlug = (title: string): string => {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '') // Remove special characters
-    .replace(/\s+/g, '-') // Replace spaces with hyphens
-    .replace(/-+/g, '-') // Replace multiple hyphens with single
-    .trim();
+    return title
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '') // Remove special characters
+        .replace(/\s+/g, '-') // Replace spaces with hyphens
+        .replace(/-+/g, '-') // Replace multiple hyphens with single
+        .trim();
 };
 
 /**
  * Find gear item by slug
  */
 export const findGearBySlug = (gear: any[], slug: string) => {
-  return gear.find(item => createGearSlug(item.title) === slug);
+    return gear.find(item => createGearSlug(item.title) === slug);
 };
 
 /**
  * Build gear URL with filters and optional item
  */
 export const buildGearUrl = (filters: {
-  category?: string;
-  brand?: string;
-  packList?: string;
-  search?: string;
+    category?: string;
+    brand?: string;
+    packList?: string;
+    search?: string;
 }, itemSlug?: string): string => {
-  const params = new URLSearchParams();
-  
-  // Add filters
-  if (filters.category) params.set('category', filters.category);
-  if (filters.brand) params.set('brand', filters.brand);
-  if (filters.packList) params.set('packList', filters.packList);
-  if (filters.search) params.set('search', filters.search);
-  
-  // Add item
-  if (itemSlug) params.set('item', itemSlug);
-  
-  const queryString = params.toString();
-  return queryString ? `/gear?${queryString}` : '/gear';
+    const params = new URLSearchParams();
+
+    // Add filters
+    if (filters.category) params.set('category', filters.category);
+    if (filters.brand) params.set('brand', filters.brand);
+    if (filters.packList) params.set('packList', filters.packList);
+    if (filters.search) params.set('search', filters.search);
+
+    // Add item
+    if (itemSlug) params.set('item', itemSlug);
+
+    const queryString = params.toString();
+    return queryString ? `/gear?${queryString}` : '/gear';
 };
 
 /**
  * Parse URL search params to filter state
  */
 export const parseGearFilters = (searchParams: URLSearchParams) => {
-  return {
-    category: searchParams.get('category') || '',
-    brand: searchParams.get('brand') || '',
-    packList: searchParams.get('packList') || '',
-    search: searchParams.get('search') || '',
-    item: searchParams.get('item') || '',
-  };
+    return {
+        category: searchParams.get('category') || '',
+        brand: searchParams.get('brand') || '',
+        packList: searchParams.get('packList') || '',
+        search: searchParams.get('search') || '',
+        item: searchParams.get('item') || '',
+    };
 };
 
 /**
  * Safely encode filter values for URLs while preserving readability
  */
 export const encodeFilterValue = (value: string): string => {
-  return encodeURIComponent(value);
+    return encodeURIComponent(value);
 };
 
 /**
  * Safely decode filter values from URLs
  */
 export const decodeFilterValue = (value: string): string => {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value; // Return original if decoding fails
-  }
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value; // Return original if decoding fails
+    }
 };

--- a/public/gear-placeholder.svg
+++ b/public/gear-placeholder.svg
@@ -1,0 +1,6 @@
+<svg width="300" height="200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="300" height="200" fill="#f3f4f6"/>
+  <text x="150" y="100" text-anchor="middle" dy="0.35em" font-family="system-ui" font-size="16" fill="#6b7280">
+    Gear Image
+  </text>
+</svg>

--- a/styles/GearGrid.module.css
+++ b/styles/GearGrid.module.css
@@ -352,6 +352,141 @@
   border-radius: 8px;
 }
 
+/* Share Button Styles */
+.shareButton {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  padding: 8px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+}
+
+.gearCard:hover .shareButton {
+  opacity: 1;
+}
+
+.shareButton:hover {
+  background: rgba(0, 0, 0, 0.9);
+}
+
+/* Updated CSS for inline share button and toast */
+
+/* Link container for View Product and Share */
+.linkContainer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #4A6FA5;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease;
+  flex: 1;
+}
+
+.link:hover {
+  color: #2D5A3D;
+  text-decoration: underline;
+}
+
+.shareLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  background: transparent;
+  border: 1px solid var(--color-bg-tertiary);
+  border-radius: 0.375rem;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.shareLink:hover {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  border-color: var(--color-text-secondary);
+}
+
+/* Toast notification */
+.toast {
+  position: fixed;
+  top: 2rem;
+  right: 2rem;
+  z-index: 1000;
+  animation: slideIn 0.3s ease-out;
+}
+
+.toastContent {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-bg-tertiary);
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  color: var(--color-text-primary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  backdrop-filter: blur(10px);
+}
+
+/* Toast animation */
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+/* Dark mode adjustments */
+[data-theme='dark'] .toastContent {
+  background: rgba(42, 42, 42, 0.95);
+  border-color: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .toast {
+    top: 1rem;
+    right: 1rem;
+    left: 1rem;
+  }
+  
+  .linkContainer {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+  
+  .shareLink {
+    justify-content: center;
+  }
+}
+
 /* Dark mode adjustments */
 [data-theme='dark'] .imageWrapper {
   background: linear-gradient(135deg, #2a2a2a 0%, #1a1a1a 100%);

--- a/styles/GearGrid.module.css
+++ b/styles/GearGrid.module.css
@@ -305,6 +305,53 @@
   font-size: 1.1rem;
 }
 
+.imageWrapper {
+  position: relative;
+  /* your existing styles */
+}
+
+.shareButton {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  padding: 8px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.gearCard:hover .shareButton {
+  opacity: 1;
+}
+
+.shareButton:hover {
+  background: rgba(0, 0, 0, 0.9);
+}
+
+/* Smooth transition for scroll highlighting */
+.gearCard {
+  transition: box-shadow 0.3s ease;
+  /* your existing styles */
+}
+
+/* Development placeholder styling */
+.imagePlaceholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+  height: 200px;
+  border-radius: 8px;
+}
+
 /* Dark mode adjustments */
 [data-theme='dark'] .imageWrapper {
   background: linear-gradient(135deg, #2a2a2a 0%, #1a1a1a 100%);


### PR DESCRIPTION
# Add URL filtering and gear sharing to gear list

## Summary
Implements shareable URLs for gear filters and individual items, plus development image optimization.

## Changes
- **URL-based filtering**: Category, brand, and pack list filters update URL for sharing
- **Item linking**: Generate shareable links to specific gear items with filters preserved
- **Auto-scroll**: Page scrolls to gear grid when filters applied via URL
- **Share functionality**: Copy-to-clipboard buttons with toast notifications
- **Development optimization**: Use placeholder images in dev to reduce Notion API calls
- **Search improvements**: Local-only search (no URL updates or scrolling)

## Technical Details
- Created `gearUrlUtils.ts` for URL management and slug generation
- Added scroll prevention for double-scroll issues
- Share buttons positioned next to "View Product" for mobile accessibility
- Toast notifications match site styling with CSS variables

## Example URLs
- Filtered: `/gear?category=ski-gear&brand=osprey`
- Specific item: `/gear?category=ski-gear&item=findr-102-skis`